### PR TITLE
Issue #1: set up a Vagrant container for Lustrous

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 # Vagrant's internal data
 .vagrant/
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-# Vagrant data
+# Vagrant's internal data
 .vagrant/

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Vagrant data
+.vagrant/

--- a/README.md
+++ b/README.md
@@ -9,31 +9,32 @@ Lustrous provides a complete and self–contained, isolated, portable and reprod
 This section assumes you are using [Debian GNU/Linux](https://www.debian.org/), [Ubuntu](http://www.ubuntu.com/) or another decent Debian–based distribution.
 
 1. Install [Git](http://git-scm.com/):
-
-    $ sudo apt-get install git
-
+```
+$ sudo apt-get install git
+```
 2. Install the [Network File System (NFS)](https://en.wikipedia.org/wiki/Network_File_System) server:
-
-    $ sudo apt-get install nfs-kernel-server
-
+```
+$ sudo apt-get install nfs-kernel-server
+```
 3. Install the latest [VirtualBox](https://www.virtualbox.org/)
 4. Install the latest [Vagrant](https://www.vagrantup.com/)
 5. Clone the [Lustrous GitHub repository](https://github.com/michalroszka/lustrous) and start up the environment:
-
-    $ git clone https://github.com/michalroszka/lustrous.git
-    $ cd lustrous
-    $ vagrant up
-
+```
+$ git clone https://github.com/michalroszka/lustrous.git
+$ cd lustrous
+$ vagrant up
+```
 6. Start an interactive shell:
-
-    $ vagrant ssh
-
+```
+$ vagrant ssh
+```
 7. The `/vagrant` folder corresponds to the Lusterous folder on your host machine, and its contents is shared. This allows you to use your normal editor environment on your host machine to edit the code that runs on your virtual machine.
 
 8. Test your code:
-
-    $ varnishd -C -f /vagrant/example/example.vcl
-    $ varnishtest /vagrant/tests/example.vtc
+```
+$ varnishd -C -f /vagrant/example/example.vcl
+$ varnishtest /vagrant/tests/example.vtc
+```
 
 ## License ##
 

--- a/README.md
+++ b/README.md
@@ -10,14 +10,14 @@ This section assumes you are using [Debian GNU/Linux](https://www.debian.org/), 
 
 1. Install [Git](http://git-scm.com/):
 
-        ```
-        $ sudo apt-get install git
-        ```
+    ```
+    $ sudo apt-get install git
+    ```
 2. Install the [Network File System (NFS)](https://en.wikipedia.org/wiki/Network_File_System) server:
 
-        ```
-        $ sudo apt-get install nfs-kernel-server
-        ```
+    ```
+    $ sudo apt-get install nfs-kernel-server
+    ```
 3. Install the latest [VirtualBox](https://www.virtualbox.org/)
 4. Install the latest [Vagrant](https://www.vagrantup.com/)
 5. Clone the [Lustrous GitHub repository](https://github.com/michalroszka/lustrous) and start up the environment:

--- a/README.md
+++ b/README.md
@@ -9,14 +9,14 @@ Lustrous provides a complete and self–contained, isolated, portable and reprod
 This section assumes you are using [Debian GNU/Linux](https://www.debian.org/), [Ubuntu](http://www.ubuntu.com/) or another decent Debian–based distribution.
 
 1. Install [Git](http://git-scm.com/):
-```
-$ sudo apt-get install git
-```
+        ```
+        $ sudo apt-get install git
+        ```
 2. Install the [Network File System (NFS)](https://en.wikipedia.org/wiki/Network_File_System) server:
 ```
 $ sudo apt-get install nfs-kernel-server
 ```
-3. Install the latest [VirtualBox](https://www.virtualbox.org/)
+\3. Install the latest [VirtualBox](https://www.virtualbox.org/)
 4. Install the latest [Vagrant](https://www.vagrantup.com/)
 5. Clone the [Lustrous GitHub repository](https://github.com/michalroszka/lustrous) and start up the environment:
 ```

--- a/README.md
+++ b/README.md
@@ -9,9 +9,11 @@ Lustrous provides a complete and self–contained, isolated, portable and reprod
 This section assumes you are using [Debian GNU/Linux](https://www.debian.org/), [Ubuntu](http://www.ubuntu.com/) or another decent Debian–based distribution.
 
 1. Install [Git](http://git-scm.com/):
+
         ```
         $ sudo apt-get install git
         ```
+
 2. Install the [Network File System (NFS)](https://en.wikipedia.org/wiki/Network_File_System) server:
 ```
 $ sudo apt-get install nfs-kernel-server

--- a/README.md
+++ b/README.md
@@ -13,30 +13,33 @@ This section assumes you are using [Debian GNU/Linux](https://www.debian.org/), 
         ```
         $ sudo apt-get install git
         ```
-
 2. Install the [Network File System (NFS)](https://en.wikipedia.org/wiki/Network_File_System) server:
-```
-$ sudo apt-get install nfs-kernel-server
-```
-\3. Install the latest [VirtualBox](https://www.virtualbox.org/)
+
+        ```
+        $ sudo apt-get install nfs-kernel-server
+        ```
+3. Install the latest [VirtualBox](https://www.virtualbox.org/)
 4. Install the latest [Vagrant](https://www.vagrantup.com/)
 5. Clone the [Lustrous GitHub repository](https://github.com/michalroszka/lustrous) and start up the environment:
-```
-$ git clone https://github.com/michalroszka/lustrous.git
-$ cd lustrous
-$ vagrant up
-```
+
+    ```
+    $ git clone https://github.com/michalroszka/lustrous.git
+    $ cd lustrous
+    $ vagrant up
+    ```
 6. Start an interactive shell:
-```
-$ vagrant ssh
-```
+
+    ```
+    $ vagrant ssh
+    ```
 7. The `/vagrant` folder corresponds to the Lusterous folder on your host machine, and its contents is shared. This allows you to use your normal editor environment on your host machine to edit the code that runs on your virtual machine.
 
 8. Test your code:
-```
-$ varnishd -C -f /vagrant/example/example.vcl
-$ varnishtest /vagrant/tests/example.vtc
-```
+
+    ```
+    $ varnishd -C -f /vagrant/example/example.vcl
+    $ varnishtest /vagrant/tests/example.vtc
+    ```
 
 ## License ##
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,39 @@
 # Lustrous #
 
-A test–driven approach to Varnish configuration.
+**Lustrous is a work in progress at a very early stage of development. Chances are, the documentation is incomplete, inaccurate or simply missing. Please contact [me](https://github.com/michalroszka) directly for any information on the project.**
+
+Lustrous provides a complete and self–contained, isolated, portable and reproducible environment for working with [Varnish](https://www.varnish-cache.org/) configuration. Lustrous stands on the shoulders of giants and is built on top of industry–standard technology. It offers the quickest possible start into the Varnish Configuration Language. With a healthy dose of automation, it makes test–driven Varnish configuration easier than ever.
+
+## Quick Start ##
+
+This section assumes you are using [Debian GNU/Linux](https://www.debian.org/), [Ubuntu](http://www.ubuntu.com/) or another decent Debian–based distribution.
+
+1. Install [Git](http://git-scm.com/):
+
+    $ sudo apt-get install git
+
+2. Install the [Network File System (NFS)](https://en.wikipedia.org/wiki/Network_File_System) server:
+
+    $ sudo apt-get install nfs-kernel-server
+
+3. Install the latest [VirtualBox](https://www.virtualbox.org/)
+4. Install the latest [Vagrant](https://www.vagrantup.com/)
+5. Clone the [Lustrous GitHub repository](https://github.com/michalroszka/lustrous) and start up the environment:
+
+    $ git clone https://github.com/michalroszka/lustrous.git
+    $ cd lustrous
+    $ vagrant up
+
+6. Start an interactive shell:
+
+    $ vagrant ssh
+
+7. The `/vagrant` folder corresponds to the Lusterous folder on your host machine, and its contents is shared. This allows you to use your normal editor environment on your host machine to edit the code that runs on your virtual machine.
+
+8. Test your code:
+
+    $ varnishd -C -f /vagrant/example/example.vcl
+    $ varnishtest /vagrant/tests/example.vtc
 
 ## License ##
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,13 @@
+
+# Configuration of the Vagrant container for Lustrous.
+
+Vagrant.configure(2) do |config|
+
+	# Ubuntu 15.04 (Vivid Vervet), amd64.
+	config.vm.box = "ubuntu/vivid64"
+
+	# Automated provisioning, see botstrap.sh for details.
+	config.vm.provision :shell, path: "bootstrap.sh"
+
+end
+

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+# Provisioning of the Vagrant container for Lustrous.
+
+# Update lists of packages.
+apt-get update
+

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -5,3 +5,5 @@
 # Update lists of packages.
 apt-get update
 
+# Install Varnish and its documentation.
+apt-get install -y varnish varnish-doc

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -7,3 +7,4 @@ apt-get update
 
 # Install Varnish and its documentation.
 apt-get install -y varnish varnish-doc
+


### PR DESCRIPTION
Issue: #1 

## Step 1: start with a basic 64-bit Ubuntu box ##

The Vagrant container for Lustrous is built on top of the latest stable Ubuntu Server release for amd64. Configuration of the container is in `Vagrantfile`. Provisioning is controlled by a simple shell script `bootstrap.sh`.

## Step 2: install `varnish` and `varnish-doc` on the box ##

Implemented in `bootstrap.sh`, a simple `apt-get install` call.

## Step 3: configure synced folders ##

Nothing to do. Vagrant mounts the project root as `/vagrant` by default.

## Step 4: update the README ##

## References: ##

* https://docs.vagrantup.com/v2/getting-started/boxes.html
* https://atlas.hashicorp.com/ubuntu/boxes/vivid64
* https://docs.vagrantup.com/v2/getting-started/provisioning.html
* https://www.varnish-cache.org/releases
* https://www.varnish-cache.org/unstable-releases
* http://packages.ubuntu.com/vivid/varnish
* https://docs.vagrantup.com/v2/getting-started/synced_folders.html