### PR TITLE
implement an example test case

### DIFF
--- a/example/example.vcl
+++ b/example/example.vcl
@@ -1,0 +1,9 @@
+
+# An Example Lustrous Varnish Configuration
+
+vcl 4.0;
+
+sub vcl_deliver {
+	set resp.http.X-Served-By = "Lustrous";
+}
+

--- a/example/tests/example.vtc
+++ b/example/tests/example.vtc
@@ -1,0 +1,55 @@
+
+# An Example Lustrous Test Case.
+
+# Set a human–friendly identifier for the test case.
+varnishtest "An Example Lustrous Test Case"
+
+# Mock a backend server for the test case and start it.
+server s1 {
+
+	# Receive an HTTP request.
+	rxreq
+
+	# Set HTTP response body.
+	txresp -body "Welcome to Lustrous!"
+
+} -start
+
+# Mock a Varnish server for the test case and start it.
+varnish v1 -vcl {
+
+	# Specify the backend server.
+	backend default {
+		.host = "${s1_addr}";
+		.port = "${s1_port}";
+	}
+
+	# Include the VCL to test.
+	# TODO: Find a way to use a relative path here.
+	include "/vagrant/example/example.vcl";
+
+} -start
+
+# Mock a client for the test case and run it.
+client c1 {
+
+	# Transmit an HTTP request.
+	txreq
+
+	# Receive an HTTP response.
+	rxresp
+
+	# Assertions.
+	# If any assertion is false, the test will fail.
+
+	# Assertion: HTTP status code.
+	expect resp.status == 200
+
+	# Assertion: HTTP response header.
+	expect resp.http.X-Served-By == "Lustrous"
+
+	# Assertion: HTTP response body.
+	expect resp.body == "Welcome to Lustrous!"
+
+} -run
+


### PR DESCRIPTION
Issue #6 

VCL to test is in `example/example.vcl`. The test case is
in `example/tests/example.vtc`.

The test case sets up a backend server that receives an HTTP request
and sends an HTTP response with the body `Welcome to Lustrous!`.

The test case sets up a client that sends an HTTP request and performs
assertions against the returned HTTP response.

The test case sets up a Varnish between the client and the server and
includes the logic from `example/example.vcl` that adds an `X-Served-By`
HTTP header to the response the value of which is `Lustrous`.

It implies the assertions in the test case are:

* HTTP status code is 200; the transaction went fine.
* The body of the HTTP response is `Welcome to Lustrous!`, originating
  from the backend server.
* The value of the `X-Served-By` header is `Lustrous`, added
  by the tested VCL.

The VCL is included by its absolute path. I need to find a way to use
relative paths to make tests portable and to reduce repetitions.