### PR TITLE
issue #9: reenable the main varnish service on boot

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -11,10 +11,6 @@ apt-get upgrade -y
 # Install Varnish and its documentation.
 apt-get install -y varnish varnish-doc
 
-# Stop and disable the Varnish daemon.
-systemctl stop varnish.service
-systemctl disable varnish.service
-
 # Stop and disable Varnish logging daemon.
 systemctl stop varnishlog.service
 systemctl disable varnishlog.service


### PR DESCRIPTION
issue #9: reenable the main varnish service on boot

A running Varnish deamon is needed for proper VCL syntax checks, e.g.
`sudo /usr/share/varnish/reload-vcl -c /vagrant/example/example.vcl`.