### PR TITLE
issue #7: install nginx and make it serving a simple home page and Varnish documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,5 +51,5 @@ This section assumes you are using [Debian GNU/Linux](https://www.debian.org/), 
 
 Lustrous is provided under
 the [MIT License](https://opensource.org/licenses/MIT). See accompanying
-LICENSE.md for details.
+`LICENSE.md` for details.
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -9,5 +9,8 @@ Vagrant.configure(2) do |config|
 	# Automated provisioning, see botstrap.sh for details.
 	config.vm.provision :shell, path: "bootstrap.sh"
 
+	# Make VM's web server accessible from the host system.
+	config.vm.network :forwarded_port, guest: 80, host: 8888
+
 end
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -29,3 +29,6 @@ systemctl disable varnishncsa.service
 # it is easily accessible from the host system's Web browser.
 ln --verbose --symbolic /usr/share/doc/varnish-doc/html /var/www/html/varnish-doc
 
+# Put the Lustrous' home page in nginx's document root.
+cp --verbose /vagrant/index.html /var/www/html/
+

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -25,3 +25,7 @@ systemctl disable varnishlog.service
 systemctl stop varnishncsa.service
 systemctl disable varnishncsa.service
 
+# Create a symbolic link to Varnish documentation so that
+# it is easily accessible from the host system's Web browser.
+ln --verbose --symbolic /usr/share/doc/varnish-doc/html /var/www/html/varnish-doc
+

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -11,6 +11,12 @@ apt-get upgrade -y
 # Install Varnish and its documentation.
 apt-get install -y varnish varnish-doc
 
+# Install a light version of nginx with only a minimal set of features.
+apt-get install -y nginx-light
+
+# Remove all unused packages.
+apt-get autoremove -y
+
 # Stop and disable Varnish logging daemon.
 systemctl stop varnishlog.service
 systemctl disable varnishlog.service

--- a/index.html
+++ b/index.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+	<meta charset="utf-8">
+	<title>Lustrous</title>
+</head>
+
+<body>
+	<h1>Lustrous</h1>
+
+	<h2>Lustrous Documentation</h2>
+
+	<ul>
+		<li><a href="https://github.com/michalroszka/lustrous">Lustrous on GitHub</a></li>
+		<li><a href="https://github.com/michalroszka/lustrous/issues">Lustrous Known Issues</a></li>
+	</ul>
+
+	<h2>Varnish Administrator Documentation</h2>
+
+	<ul>
+		<li><a href="/varnish-doc/index.html">Home page</a></li>
+		<li><a href="/varnish-doc/installation/index.html">Varnish Installation</a></li>
+		<li><a href="/varnish-doc/tutorial/index.html">The Varnish Tutorial</a></li>
+		<li><a href="/varnish-doc/users-guide/index.html">The Varnish Users Guide</a></li>
+		<li><a href="/varnish-doc/reference/index.html">The Varnish Reference Manual</a></li>
+		<li><a href="/varnish-doc/whats-new/index.html">What's new in Varnish 4.0</a></li>
+		<li><a href="/varnish-doc/phk/index.html">Poul-Hennings random outbursts</a></li>
+		<li><a href="/varnish-doc/glossary/index.html">Varnish Glossary</a></li>
+		<li><a href="/varnish-doc/varnish-doc/genindex.html">Index</a></li>
+		<li><a href="/varnish-doc/search.html">Search</a></li>
+	</ul>
+
+	<p>Copyright &copy; 2015 Michał Roszka. Lustrous is provided under the <a href="https://opensource.org/licenses/MIT">MIT License</a>.</p>
+</p>
+</body>
+
+</html>
+


### PR DESCRIPTION
issue #7: install nginx and make it serving a simple home page and Varnish documentation

The home page is available at http://localhost:8888/ and the documentation at http://localhost:8888/varnish-doc/.