### PR TITLE
issue #24: adjust synced directories configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,13 +38,13 @@ This section assumes you are using [Debian GNU/Linux](https://www.debian.org/), 
     ```
     $ vagrant ssh
     ```
-7. The `/vagrant` folder corresponds to the Lustrous folder on your host machine, and its contents is shared. This allows you to use your normal editor environment on your host machine to edit the code that runs on your virtual machine.
+7. The `/home/vagrant/vcl/` folder corresponds to the Lustrous' `vcl/` folder on your host machine, and its contents is shared. This allows you to use your normal editor environment on your host machine to edit the code that runs on your virtual machine.
 
 8. Test your code:
 
     ```
-    $ sudo /usr/share/varnish/reload-vcl -c /vagrant/example/example.vcl
-    $ varnishtest /vagrant/tests/example.vtc
+    $ sudo /usr/share/varnish/reload-vcl -c /home/vagrant/vcl/example/example.vcl
+    $ varnishtest /home/vagrant/vcl/example/tests/example.vtc
     ```
 
 ## License ##

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -18,5 +18,19 @@ Vagrant.configure(2) do |config|
 		v.name = "lustrous"
 	end
 
+	# Mount the VCL directory in "/home/vagrant/vcl" so that
+	# it is easier to access.
+	config.vm.synced_folder "vcl/", "/home/vagrant/vcl",
+		owner: "vagrant", group: "vagrant"
+
+	# Mount the provisioner's directory to in "/provision"
+	# so that it stands out of the way.
+	config.vm.synced_folder "provision/", "/provision",
+		owner: "root", group: "root"
+
+	# Disable the default share so that it stands out of the way.
+	config.vm.synced_folder "./", "/vagrant",
+		disabled: true
+
 end
 

--- a/provision/bootstrap.sh
+++ b/provision/bootstrap.sh
@@ -30,5 +30,5 @@ systemctl disable varnishncsa.service
 ln --force --verbose --symbolic /usr/share/doc/varnish-doc/html /var/www/html/varnish-doc
 
 # Put the Lustrous' home page in nginx's document root.
-cp --force --verbose /vagrant/provision/index.html /var/www/html/
+cp --force --verbose /provision/index.html /var/www/html/
 

--- a/vcl/example/tests/example.vtc
+++ b/vcl/example/tests/example.vtc
@@ -26,7 +26,7 @@ varnish v1 -vcl {
 
 	# Include the VCL to test.
 	# TODO: Find a way to use a relative path here.
-	include "/vagrant/example/example.vcl";
+	include "/home/vagrant/vcl/example/example.vcl";
 
 } -start
 


### PR DESCRIPTION
issue #24: adjust synced directories configuration

* adjust the synced directories configuration
    * disable the default share and mount the host's `provision/` in guest's `/provision` so that the unnecessary stuff stands out of the user's way;
    * mount host's `vcl/` in guest's `/home/vagrant/vcl` so that it is easier to access;
* refine `example.vtc` to reflect synced directories changes 
* refine the provisioner to reflect synced directories changes 
* update the README so it reflects synced directories changes 