### PR TITLE
issue #11: serve varnishtest sources

### DIFF
--- a/provision/bootstrap.sh
+++ b/provision/bootstrap.sh
@@ -27,6 +27,7 @@ systemctl disable varnishncsa.service
 
 # Create a symbolic link to Varnish documentation so that
 # it is easily accessible from the host system's Web browser.
+rm --force --verbose /var/www/html/varnish-doc
 ln --force --verbose --symbolic /usr/share/doc/varnish-doc/html /var/www/html/varnish-doc
 
 # Put the Lustrous' home page in nginx's document root.

--- a/provision/bootstrap.sh
+++ b/provision/bootstrap.sh
@@ -33,3 +33,12 @@ ln --force --verbose --symbolic /usr/share/doc/varnish-doc/html /var/www/html/va
 # Put the Lustrous' home page in nginx's document root.
 cp --force --verbose /provision/index.html /var/www/html/
 
+# Download the source code of Varnish Debian package and create
+# a symbolic link to the source code of varnishtest
+# and its regression tests is easily accessible from the host
+# system's Web browser.
+rm --force --verbose --recursive /usr/src/pkg-varnish
+git clone git://anonscm.debian.org/pkg-varnish/pkg-varnish.git /usr/src/pkg-varnish
+rm --force --verbose /var/www/html/varnishtest-src
+ln --force --verbose --symbolic /usr/src/pkg-varnish/bin/varnishtest /var/www/html/varnishtest-src
+

--- a/provision/bootstrap.sh
+++ b/provision/bootstrap.sh
@@ -42,3 +42,10 @@ git clone git://anonscm.debian.org/pkg-varnish/pkg-varnish.git /usr/src/pkg-varn
 rm --force --verbose /var/www/html/varnishtest-src
 ln --force --verbose --symbolic /usr/src/pkg-varnish/bin/varnishtest /var/www/html/varnishtest-src
 
+# Remove all active nginx configuration, replace it with
+# Lustrous-specific settings and restart nginx.
+rm --force --verbose /etc/nginx/sites-enabled/*
+cp --force --verbose /provision/lustrous.nginx.conf /etc/nginx/sites-available/
+ln --force --verbose --symbolic /etc/nginx/sites-available/lustrous.nginx.conf /etc/nginx/sites-enabled/lustrous
+service nginx restart
+

--- a/provision/index.html
+++ b/provision/index.html
@@ -16,6 +16,15 @@
 		<li><a href="https://github.com/michalroszka/lustrous/issues">Lustrous Known Issues</a></li>
 	</ul>
 
+	<h2>Example Varnishtest Scripts</h2>
+
+	<p>The <cite>man page for <code>varnishtest</code></cite> reads <q>the script language used for Varnishtest is not a strictly defined language. The best reference for writing scripts is the varnishtest program itself</q>.</p>
+
+	<ul>
+		<li><a href="/varnishtest-src/"><code>varnishtest</code> source code</a></li>
+		<li><a href="/varnishtest-src/tests/"><code>varnishtest</code> regression tests</a></li>
+	</ul>
+
 	<h2>Varnish Administrator Documentation</h2>
 
 	<ul>


### PR DESCRIPTION
issue #11: serve varnishtest sources

 * Remove existing symbolic links during provisioning. This is to prevent symbolic links from being created in already linked directories, e.g. `ln --force --verbose --symbolic /usr/share/doc/varnish-doc/html /var/www/html/varnish-doc` would first create `/var/www/html/varnish-doc` and, during the subsequent provisioning  `/var/www/html/varnish-doc/html`.

 * Download the source code of Varnish Debian package and create a symbolic link to the source code of varnishtest and its regression tests is easily accessible from the host system's Web browser.

* add Lustrous-specific nginx configuration
    * enable directory listings
    * serve files in `/varnishtest-src/` as plain text

* add relevant links to the home page

