### PR TITLE
issue #19 — use relative paths to VCLs in the test cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ This section assumes you are using [Debian GNU/Linux](https://www.debian.org/), 
 
     ```
     $ sudo /usr/share/varnish/reload-vcl -c /home/vagrant/vcl/example/example.vcl
-    $ varnishtest /home/vagrant/vcl/example/tests/example.vtc
-```
+    $ varnishtest -D vcl_root=/home/vagrant/vcl/example /home/vagrant/vcl/example/tests/example.vtc
+    ```
 
 9. Open [http://localhost:8888/](http://localhost:8888/) in your Web browser for more information and documentation.
 

--- a/vcl/example/tests/example.vtc
+++ b/vcl/example/tests/example.vtc
@@ -25,8 +25,7 @@ varnish v1 -vcl {
 	}
 
 	# Include the VCL to test.
-	# TODO: Find a way to use a relative path here.
-	include "/home/vagrant/vcl/example/example.vcl";
+	include "${vcl_root}/example.vcl";
 
 } -start
 


### PR DESCRIPTION
issue #19 — use relative paths to VCLs in the test cases

This is where so called macros come into play: `varnishtest -D vcl_root=/some/directory path/to/test.vtc` will result with `/some/directory` stored in `{$vcl_root}` in the test script.

The README has been updated, too.