### PR TITLE
issue #3 — implement a test runner as a vagrant plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,8 @@ This section assumes you are using [Debian GNU/Linux](https://www.debian.org/), 
 
 8. Test your code:
 
-    ```
-    $ sudo /usr/share/varnish/reload-vcl -c /home/vagrant/vcl/example/example.vcl
-    $ varnishtest -D vcl_root=/home/vagrant/vcl/example /home/vagrant/vcl/example/tests/example.vtc
-    ```
+    * `$ varnishtest -D vcl_root=/home/vagrant/vcl/example /home/vagrant/vcl/example/tests/example.vtc` runs one particular test
+    * `$ make --directory=/home/vagrant/vcl/ PREFIX=example` runs all tests from `/home/vagrant/vcl/example/tests/`
 
 9. Open [http://localhost:8888/](http://localhost:8888/) in your Web browser for more information and documentation.
 

--- a/vcl/Makefile
+++ b/vcl/Makefile
@@ -1,0 +1,20 @@
+#!/usr/bin/env make -f
+
+default: test
+
+help:
+	@echo	'Possible targets:'
+	@echo	'  help - Print this help'
+	@echo	'  test - Run tests (Varnish test cases)'
+
+test:
+	@echo	'Running tests (Varnish test cases).'
+	@find $(CURDIR)/$(PREFIX)/tests \
+		-type f \
+		-name "*.vtc" \
+		-print0 \
+		| xargs -0 \
+		varnishtest -D vcl_root=$(CURDIR)/$(PREFIX) \
+
+.PHONY: help test
+


### PR DESCRIPTION
issue #3 — implement a test runner as a vagrant plugin

 * created a naive `Makefile`
    * Usage: `make --directory=/home/vagrant/vcl/ PREFIX=example` runs the the tests
in `/home/vagrant/vcl/example/tests`.
* updated the README